### PR TITLE
chore: Removed arguments functionality

### DIFF
--- a/lib/injectable.rb
+++ b/lib/injectable.rb
@@ -12,49 +12,30 @@ require 'injectable/method_already_exists_exception'
 # @example
 #   You would create a service like this:
 #
-#   class AddPlayerToTeamRoster
+#   class MyPack::Commands::AddPlayerToTeamRoster
 #     include Injectable
 #
-#     dependency :team_query
-#     dependency :player_query, class: UserQuery
+#     dependency :team_repo, class: Repositories::TeamRepo
+#     dependency :player_repo, class: Repositories::PlayerRepo
 #
-#     argument :team_id
-#     argument :player_id
+#     def call(team_id:, player_id:)
+#       team = team_repo.get!(team_id)
+#       player = player_repo.get!(player_id)
 #
-#     def call
-#       player_must_exist!
-#       team_must_exist!
-#       team_must_accept_players!
-#
-#       team.add_to_roster(player)
+#       team_must_accept_players(team)
+#       team_repo.add_to_roster!(team, player)
 #     end
 #
 #     private
 #
-#     def player
-#       @player ||= player_query.call(player_id)
-#     end
-#
-#     def team
-#       @team ||= team_query.call(team_id)
-#     end
-#
-#     def player_must_exist!
-#       player.present? || raise UserNotFoundException
-#     end
-#
-#     def team_must_exist!
-#       team.present? || raise TeamNotFoundException
-#     end
-#
-#     def team_must_accept_players!
-#       team.accepts_players? || raise TeamFullException
+#     def team_must_accept_players(team)
+#       team.accepts_players? || raise Errors::TeamFullError
 #     end
 #   end
 #
 #   And use it like this:
 #
-#   AddPlayerToTeamRoster.call(player_id: player.id, team_id: team.id)
+#   AddPlayerToTeamRoster.call(player_id: "PLAYER_UUID", team_id: "TEAM_UUID")
 module Injectable
   def self.included(base)
     base.extend(Injectable::ClassMethods)

--- a/lib/injectable/dependency.rb
+++ b/lib/injectable/dependency.rb
@@ -32,6 +32,7 @@ module Injectable
       args.is_a?(Array) ? args.clone : [args]
     end
 
+    ### ???
     def wrap_call(the_instance)
       return the_instance unless call
 
@@ -43,8 +44,6 @@ module Injectable
     end
 
     def build_instance(args, kwargs, namespace:)
-      return build_instance_26(args, kwargs, namespace: namespace) if RUBY_VERSION < '2.7'
-
       instantiator = block || klass(namespace: namespace).method(:new)
       if kwargs.empty?
         # otherwise an empty hash will be added in ruby 2.7, which could be taken as
@@ -65,12 +64,6 @@ module Injectable
 
     def camelcased
       @camelcased ||= name.to_s.split('_').map(&:capitalize).join
-    end
-
-    def build_instance_26(args, kwargs, namespace:)
-      args << kwargs if kwargs.any?
-
-      block.nil? ? klass(namespace: namespace).new(*args) : block.call(*args)
     end
   end
 end

--- a/lib/injectable/instance_methods.rb
+++ b/lib/injectable/instance_methods.rb
@@ -8,24 +8,7 @@ module Injectable
       super()
     end
 
-    # Entry point of the service.
-    # Arguments for this method should be declared explicitly with '.argument'
-    # and declare this method without arguments
-    def call(args = {})
-      check_call_definition!
-      check_missing_arguments!(self.class.required_call_arguments, args)
-      variables_for!(self.class.call_arguments, args)
-      super()
-    end
-
     private
-
-    def check_call_definition!
-      return if (self.class.ancestors - [Injectable::InstanceMethods]).any? do |ancestor|
-        ancestor.instance_methods(false).include?(:call)
-      end
-      raise NoMethodError, "A #call method with zero arity must be defined in #{self.class}"
-    end
 
     def check_missing_arguments!(expected, args)
       missing = expected - args.keys

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -4,20 +4,27 @@ require_relative 'support/dependencies'
 describe Injectable do
   context 'without defined #call' do
     subject do
+      Age = Class.new do
+        include Injectable
+
+        def get_age
+          999
+        end
+      end
+
       Class.new do
         include Injectable
 
-        def self.to_s
-          'MyFancyClass'
+        dependency :age
+
+        def my_call(name:)
+          [name, age.get_age]
         end
       end
     end
 
-    it 'raises an explicit error when using #call' do
-      expect { subject.call }.to raise_error(
-        NoMethodError,
-        'A #call method with zero arity must be defined in MyFancyClass'
-      )
+    it "allows custom call methods" do
+      expect(subject.new.my_call(name: "Andrew")).to eq(["Andrew", 999])
     end
   end
 
@@ -405,9 +412,7 @@ describe Injectable do
       Class.new do
         include Injectable
 
-        argument :user_id
-
-        def call
+        def call(user_id:)
           "Value was #{user_id}"
         end
       end
@@ -419,8 +424,7 @@ describe Injectable do
 
     it 'requires them' do
       expect { subject.call }.to raise_error(
-        ArgumentError,
-        'missing keywords: user_id'
+        ArgumentError
       )
     end
   end
@@ -430,9 +434,7 @@ describe Injectable do
       Class.new do
         include Injectable
 
-        argument :status, default: 'standby'
-
-        def call
+        def call(status: "standby")
           "Value is #{status}"
         end
       end
@@ -500,9 +502,7 @@ describe Injectable do
           'this comes from parent'
         end
 
-        argument :parent_arg
-
-        def call
+        def call(parent_arg:)
           "Returning #{parent_dep} and #{parent_arg}"
         end
       end
@@ -533,7 +533,6 @@ describe Injectable do
 
       let(:sibling) do
         Sibling = Class.new(parent) do
-          argument :required
         end
       end
 


### PR DESCRIPTION
## Description

We want to remove the `argument` functionality from the injectable library because the weirdness of it does not justify it's usefulness to us.